### PR TITLE
chore: declare @feature:chat disable + use disables-aware test runner

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -15,9 +15,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
-          # TEMPORARY: ride the feature-tags branch until ether/etherpad-lite#7648
-          # lands on develop. Drop the `ref` once that merges.
-          ref: feat/feature-tags-disables-contract
           path: etherpad-lite
       - uses: actions/setup-node@v4
         name: Install Node.js

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ether/etherpad-lite
+          # TEMPORARY: ride the feature-tags branch until ether/etherpad-lite#7648
+          # lands on develop. Drop the `ref` once that merges.
+          ref: feat/feature-tags-disables-contract
           path: etherpad-lite
       - uses: actions/setup-node@v4
         name: Install Node.js
@@ -69,4 +72,11 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # this plugin's ep.json declares `disables: ["@feature:chat"]`,
+          # so the helper runs two passes — regression (everything not
+          # tagged @feature:chat must pass) + honesty (every test
+          # tagged @feature:chat must FAIL because the plugin really
+          # does disable chat). Both must succeed for CI to be green.
+          # See ether/etherpad-lite#7648 / doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,5 +1,5 @@
-
 {
+  "disables": ["@feature:chat"],
   "parts":[
     {
       "name": "ep_disable_chat",


### PR DESCRIPTION
Proof-of-concept for the declared-disables contract proposed in [ether/etherpad-lite#7648](https://github.com/ether/etherpad-lite/pull/7648). **Don't merge until that lands.**

## Changes

- **`ep.json`**: declare `"disables": ["@feature:chat"]`. Surfaces in plugin metadata and (eventually) on etherpad.org/plugins so users see what the plugin removes before installing.
- **`.github/workflows/frontend-tests.yml`**: swap `pnpm run test-ui` for `bin/run-frontend-tests-with-disables.sh`. The helper runs two passes:
  - **Regression** — every test *not* tagged `@feature:chat` must pass. Catches collateral damage.
  - **Honesty** — every test *that is* tagged `@feature:chat` must FAIL. Catches the case where the plugin claims to disable chat but chat actually still works (i.e., would silently shed test coverage).

## Why a temporary pin?

The helper script doesn't exist on `develop` yet — it's introduced by ether/etherpad-lite#7648. The workflow temporarily pins the Etherpad core checkout to that PR's branch (`feat/feature-tags-disables-contract`) so this PR's CI exercises the full design. The `ref:` line carries a TODO to remove it once #7648 merges.

## Expected CI outcome (once #7648 is in scope)

- Pass 1 (`--grep-invert "@feature:chat"`): green — the plugin's only effect is to hide chat, so unrelated tests pass.
- Pass 2 (`--grep "@feature:chat"`): every chat test fails as designed because chat is hidden. Helper inverts that into a green exit code.
- `release` job fires, v0.x.y publishes — the first time `ep_disable_chat`'s auto-publish has had a chance to run since 2026-04-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)