### PR TITLE
refactor: adopt hideCSS helper for eejsBlock_styles

### DIFF
--- a/disable_chat.js
+++ b/disable_chat.js
@@ -1,12 +1,13 @@
 'use strict';
 
-exports.eejsBlock_styles = (hookName, context, cb) => {
-  context.content += `<style>
-    .hide-for-mobile { display:none !important; }
-    #chaticon, #chatbox { display: none !important; }
+const {hideCSS} = require('ep_plugin_helpers');
+
+exports.eejsBlock_styles = hideCSS('.hide-for-mobile, #chaticon, #chatbox', {
+  // Once chat is hidden the users panel takes over the full popup; without
+  // these height rules the popup collapses to the (now-empty) chat region.
+  extra: `
     #users { height:100%; }
     .popup#users.chatAndUsers > .popup-content { height:100%; }
     .popup#users.chatAndUsers { height:100%; }
-  </style>`;
-  cb();
-};
+  `,
+});

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/ether/ep_disable_chat"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.5.0
+        version: 0.5.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -399,6 +403,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.5.2:
+    resolution: {integrity: sha512-6M0gYqRTaF2SnTvV1OiqOZQ4B37ZHL0Zjoz3/eOIAXeCEBA4jId62uz9uboLs87Qcfae7eirDYWpdir5u5zkEQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1672,6 +1680,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.5.2: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
Replaces hand-rolled `<style>` tag concatenation with `hideCSS(selector, {extra: ...})` from `ep_plugin_helpers`. The helper handles the `display: none !important` boilerplate; `extra` carries the layout rules needed once chat is hidden (`#users` height handling).

Wave 4 of the Phase 4 sweep: helper adoption for `ep_disable_*` plugins.